### PR TITLE
Skal vise vilkårikon riktig selv med page-break

### DIFF
--- a/src/server/components/Vilkårsvurdering.tsx
+++ b/src/server/components/Vilkårsvurdering.tsx
@@ -19,13 +19,13 @@ interface Props {
 const resultatIkon = (resultat: Vilkårsresultat) => {
   switch (resultat) {
     case Vilkårsresultat.OPPFYLT:
-      return <OppfyltIkon />;
+      return <OppfyltIkon heigth={24} width={24} />;
     case Vilkårsresultat.IKKE_OPPFYLT:
-      return <IkkeOppfylt />;
+      return <IkkeOppfylt heigth={24} width={24} />;
     case Vilkårsresultat.SKAL_IKKE_VURDERES:
-      return <InfoIkon />;
+      return <InfoIkon heigth={24} width={24} />;
     default:
-      return <IkkeVurdert />;
+      return <IkkeVurdert heigth={24} width={24} />;
   }
 };
 

--- a/src/server/components/ikoner/IkkeVurdert.tsx
+++ b/src/server/components/ikoner/IkkeVurdert.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
-
-export const IkkeVurdert: React.FC = () => {
+interface Props {
+  className?: string;
+  heigth?: number;
+  width?: number;
+}
+export const IkkeVurdert: React.FC<Props> = ({ className, heigth, width }) => {
   return (
-    <svg aria-labelledby={'ikke vurdert'} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      aria-labelledby={'ikke vurdert'}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      height={heigth}
+      width={width}
+    >
       <title id={'ikke vurdert'}>Ikke vurdert</title>
       <path
         fill="#FFA733"

--- a/src/server/components/ikoner/InfoIkon.tsx
+++ b/src/server/components/ikoner/InfoIkon.tsx
@@ -1,8 +1,20 @@
 import * as React from 'react';
 
-const InfoIkon: React.FC = () => {
+interface Props {
+  className?: string;
+  heigth?: number;
+  width?: number;
+}
+const InfoIkon: React.FC<Props> = ({ className, heigth, width }) => {
   return (
-    <svg aria-labelledby={'ikke vurdert'} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      aria-labelledby={'ikke vurdert'}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      height={heigth}
+      width={width}
+    >
       <title id={'ikke vurdert'}>Ikke vurdert</title>
       <path
         d="M12 0C5.382 0 0 5.382 0 12s5.382 12 12 12c6.617 0 12-5.382 12-12S18.617 0 12 0z"


### PR DESCRIPTION
Må sette eksplisitt bredde og høyde så skal det funke

## Før
<img width="584" alt="Skjermbilde 2022-05-27 kl  14 25 15" src="https://user-images.githubusercontent.com/402915/170699249-b63b8be7-663e-4657-8269-2b859ce9bec9.png">

## Etter
<img width="361" alt="Skjermbilde 2022-05-27 kl  14 25 36" src="https://user-images.githubusercontent.com/402915/170699244-5c35ca52-c346-44d4-9970-cd1bcb34add0.png">