### PR TITLE
Legg til visning av ulike inntektstyper i blankett

### DIFF
--- a/src/server/components/InnvilgetOvergangsstønad.tsx
+++ b/src/server/components/InnvilgetOvergangsstønad.tsx
@@ -8,6 +8,7 @@ import {
 import {
   formaterNullableIsoDato,
   formaterNullableMånedÅr,
+  formaterBeløp,
   parseOgFormaterÅrMåned,
 } from '../utils/util';
 
@@ -49,8 +50,10 @@ export const InnvilgetOvergangsstønad: React.FC<{
           return (
             <div key={indeks}>
               <h4>Fra og med {parseOgFormaterÅrMåned(inntekt.årMånedFra)}</h4>
-              <div>Forventet inntekt (år): {inntekt.forventetInntekt}</div>
-              <div>Samordningsfradrag (mnd): {inntekt.samordningsfradrag}</div>
+              <div>Dagsats: {formaterBeløp(inntekt.dagsats || 0)}</div>
+              <div>Månedsinntekt: {formaterBeløp(inntekt.månedsinntekt || 0)}</div>
+              <div>Forventet inntekt (år): {formaterBeløp(inntekt.forventetInntekt || 0)}</div>
+              <div>Samordningsfradrag (mnd): {formaterBeløp(inntekt.samordningsfradrag || 0)}</div>
             </div>
           );
         })}

--- a/src/server/mock/dummydata.json
+++ b/src/server/mock/dummydata.json
@@ -512,7 +512,15 @@
         "periodeType": "HOVEDPERIODE"
       }
     ],
-    "inntekter": []
+    "inntekter": [
+      {
+        "årMånedFra": "2021-03",
+        "forventetInntekt": 100000,
+        "samordningsfradrag": 100,
+        "dagsats": 1000,
+        "månedsinntekt": 10000
+      }
+    ]
   },
   "søknadsdatoer": {
     "søkerStønadFra": "2021-07",

--- a/src/server/utils/util.ts
+++ b/src/server/utils/util.ts
@@ -40,3 +40,6 @@ export const tilSkoleår = (årMåned: string): number => {
 export const månedÅrTilDate = (årMåned: string): Date => {
   return parse(årMåned, 'yyyy-MM', new Date());
 };
+
+export const formaterBeløp = (verdi: number): string =>
+  Number(verdi).toLocaleString('no-NO', { currency: 'NOK' }) + ' kr';

--- a/src/typer/dokumentApi.ts
+++ b/src/typer/dokumentApi.ts
@@ -98,8 +98,10 @@ export type IVedtak =
   | IInnvilgeVedtakSkolepenger;
 export interface IInntekt {
   årMånedFra: string;
-  forventetInntekt: number;
+  forventetInntekt?: number;
   samordningsfradrag?: number;
+  dagsats?: number;
+  månedsinntekt?: number;
 }
 export enum EBehandlingResultat {
   INNVILGE = 'INNVILGE',


### PR DESCRIPTION
### Hvorfor?
Lagt inn i forbindelse med ulike inntektstyper på vedtak og beregning siden ([FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11469))

### Info
Om en av inntektstypene ikke finnes vil det stå "0kr". Dette vil skje i en del tilfeller frem til feature-toggle skrus av. Før stod det "Samordningsfradrag: " om det ikke var noe, dette er endret til "Samordningsfradrag: 0kr".

Bilde: 
![image](https://user-images.githubusercontent.com/46678893/226362093-ebb49771-2300-4494-bbb9-6ce9c6e30dd1.png)

Uten dagsats, månedsinntekt og samordningsfradrag: 
![image](https://user-images.githubusercontent.com/46678893/226362847-c15fff11-6624-4f4b-ab15-0f4b6adc96fa.png)
