### PR TITLE
Gomregning blankett

### DIFF
--- a/src/server/components/Dokument.tsx
+++ b/src/server/components/Dokument.tsx
@@ -92,6 +92,7 @@ const Dokument = (dokumentProps: DokumentProps) => {
         stønadstype={dokumentProps.dokumentData.behandling.stønadstype}
         vedtak={dokumentProps.dokumentData.vedtak}
         søknadsdatoer={dokumentProps.dokumentData.søknadsdatoer}
+        årsak={dokumentProps.dokumentData.behandling.årsak}
       />
     </div>
   );

--- a/src/server/components/Dokument.tsx
+++ b/src/server/components/Dokument.tsx
@@ -66,9 +66,11 @@ function gjelderDetteVilkåret(vurdering: IVurdering, vilkårgruppe: string): bo
 }
 
 const Dokument = (dokumentProps: DokumentProps) => {
+  const erManuellGOmregning =
+    dokumentProps.dokumentData.behandling.årsak === EBehandlingÅrsak.G_OMREGNING;
   return (
     <div>
-      {dokumentProps.dokumentData.behandling.årsak !== EBehandlingÅrsak.G_OMREGNING &&
+      {!erManuellGOmregning &&
         Object.keys(VilkårGruppe).map(vilkårgruppe => {
           const vurderinger = dokumentProps.dokumentData.vilkår.vurderinger.filter(vurdering =>
             gjelderDetteVilkåret(vurdering, vilkårgruppe),

--- a/src/server/components/Dokument.tsx
+++ b/src/server/components/Dokument.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  EBehandlingÅrsak,
   IDokumentData,
   IVilkårGrunnlag,
   IVurdering,
@@ -67,25 +68,26 @@ function gjelderDetteVilkåret(vurdering: IVurdering, vilkårgruppe: string): bo
 const Dokument = (dokumentProps: DokumentProps) => {
   return (
     <div>
-      {Object.keys(VilkårGruppe).map(vilkårgruppe => {
-        const vurderinger = dokumentProps.dokumentData.vilkår.vurderinger.filter(vurdering =>
-          gjelderDetteVilkåret(vurdering, vilkårgruppe),
-        );
-        if (vurderinger.length === 0) {
-          return null;
-        }
-        const grunnlag = dokumentProps.dokumentData.vilkår.grunnlag;
-        return vurderinger.map(vurdering => {
-          return (
-            <div key={vurdering.id} className={'page-break'}>
-              <h2>{vilkårTypeTilTekst[vurdering.vilkårType]}</h2>
-              {registergrunnlagForVilkår(grunnlag, vilkårgruppe, vurdering.barnId)}
-
-              <Vilkårsvurdering vurdering={vurdering} />
-            </div>
+      {dokumentProps.dokumentData.behandling.årsak !== EBehandlingÅrsak.G_OMREGNING &&
+        Object.keys(VilkårGruppe).map(vilkårgruppe => {
+          const vurderinger = dokumentProps.dokumentData.vilkår.vurderinger.filter(vurdering =>
+            gjelderDetteVilkåret(vurdering, vilkårgruppe),
           );
-        });
-      })}
+          if (vurderinger.length === 0) {
+            return null;
+          }
+          const grunnlag = dokumentProps.dokumentData.vilkår.grunnlag;
+          return vurderinger.map(vurdering => {
+            return (
+              <div key={vurdering.id} className={'page-break'}>
+                <h2>{vilkårTypeTilTekst[vurdering.vilkårType]}</h2>
+                {registergrunnlagForVilkår(grunnlag, vilkårgruppe, vurdering.barnId)}
+
+                <Vilkårsvurdering vurdering={vurdering} />
+              </div>
+            );
+          });
+        })}
       <Vedtak
         stønadstype={dokumentProps.dokumentData.behandling.stønadstype}
         vedtak={dokumentProps.dokumentData.vedtak}

--- a/src/server/components/InnvilgeVedtak/Begrunnelse.tsx
+++ b/src/server/components/InnvilgeVedtak/Begrunnelse.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const Begrunnelse: React.FC<{
+  begrunnelse?: string;
+}> = ({ begrunnelse }) => {
+  return (
+    <>
+      <h4>Begrunnelse</h4>
+      <p style={{ whiteSpace: 'pre-wrap' }}>{begrunnelse}</p>
+    </>
+  );
+};

--- a/src/server/components/InnvilgeVedtak/Inntektsperioder.tsx
+++ b/src/server/components/InnvilgeVedtak/Inntektsperioder.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { IInntekt } from '../../../typer/dokumentApi';
+import { formaterBeløp, parseOgFormaterÅrMåned } from '../../utils/util';
+
+export const Inntektsperioder: React.FC<{
+  inntekter: IInntekt[];
+}> = ({ inntekter }) => {
+  return (
+    <>
+      <h3>Inntekt</h3>
+      {inntekter.map((inntekt, indeks) => {
+        return (
+          <div key={indeks}>
+            <h4>Fra og med {parseOgFormaterÅrMåned(inntekt.årMånedFra)}</h4>
+            <div>Dagsats: {formaterBeløp(inntekt.dagsats || 0)}</div>
+            <div>Månedsinntekt: {formaterBeløp(inntekt.månedsinntekt || 0)}</div>
+            <div>Forventet inntekt (år): {formaterBeløp(inntekt.forventetInntekt || 0)}</div>
+            <div>Samordningsfradrag (mnd): {formaterBeløp(inntekt.samordningsfradrag || 0)}</div>
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/src/server/components/InnvilgeVedtak/Søknadsinformasjon.tsx
+++ b/src/server/components/InnvilgeVedtak/Søknadsinformasjon.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { formaterNullableIsoDato, formaterNullableMånedÅr } from '../../utils/util';
+
+export const Søknadsinformasjon: React.FC<{
+  søknadsdato: string;
+  søkerStønadFra?: string;
+}> = ({ søknadsdato, søkerStønadFra }) => {
+  return (
+    <>
+      <h3>Søknadsinformasjon</h3>
+      <div>Søknadsdato: {formaterNullableIsoDato(søknadsdato)}</div>
+      <div>Søker stønad fra: {formaterNullableMånedÅr(søkerStønadFra)}</div>
+    </>
+  );
+};

--- a/src/server/components/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/server/components/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { aktivitetsTypeTilTekst, IPeriode, periodetypeTilTekst } from '../../../typer/dokumentApi';
+import { parseOgFormaterÅrMåned } from '../../utils/util';
+
+export const Vedtaksperioder: React.FC<{
+  perioder: IPeriode[];
+}> = ({ perioder }) => {
+  return (
+    <>
+      <h3>Vedtaksperiode</h3>
+      {perioder.map((periode, indeks) => {
+        return (
+          <div key={indeks}>
+            <h4>
+              Fra og med {parseOgFormaterÅrMåned(periode.årMånedFra)} til og med{' '}
+              {parseOgFormaterÅrMåned(periode.årMånedTil)}
+            </h4>
+            <div>Periodetype: {periodetypeTilTekst[periode.periodeType]}</div>
+            <div>Aktivitet: {aktivitetsTypeTilTekst[periode.aktivitet]}</div>
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/src/server/components/InnvilgetBarnetilsyn.tsx
+++ b/src/server/components/InnvilgetBarnetilsyn.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { IInnvilgeVedtakBarnetilsyn, ISøknadsdatoer } from '../../typer/dokumentApi';
-import {
-  formaterNullableIsoDato,
-  formaterNullableMånedÅr,
-  parseOgFormaterÅrMåned,
-} from '../utils/util';
+import { parseOgFormaterÅrMåned } from '../utils/util';
+import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
 
 export const InnvilgetBarnetilsyn: React.FC<{
   vedtak: IInnvilgeVedtakBarnetilsyn;
@@ -17,11 +14,10 @@ export const InnvilgetBarnetilsyn: React.FC<{
       <h3>Resultat</h3>
       <div>Innvilge</div>
       {søknadsdatoer && (
-        <>
-          <h3>Søknadsinformasjon</h3>
-          <div>Søknadsdato: {formaterNullableIsoDato(søknadsdatoer.søknadsdato)}</div>
-          <div>Søker stønad fra: {formaterNullableMånedÅr(søknadsdatoer?.søkerStønadFra)}</div>
-        </>
+        <Søknadsinformasjon
+          søknadsdato={søknadsdatoer.søknadsdato}
+          søkerStønadFra={søknadsdatoer.søkerStønadFra}
+        />
       )}
       <h3>Vedtaksperiode</h3>
       {perioder.map((periode, indeks) => {

--- a/src/server/components/InnvilgetGOmregning.tsx
+++ b/src/server/components/InnvilgetGOmregning.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { IInnvilgeVedtakOvergangsstønad } from '../../typer/dokumentApi';
+import { Begrunnelse } from './InnvilgeVedtak/Begrunnelse';
+import { Inntektsperioder } from './InnvilgeVedtak/Inntektsperioder';
+import { Vedtaksperioder } from './InnvilgeVedtak/Vedtaksperioder';
+
+export const InnvilgetGOmregning: React.FC<{
+  vedtak: IInnvilgeVedtakOvergangsstønad;
+}> = ({ vedtak }) => {
+  const { periodeBegrunnelse, perioder, inntektBegrunnelse, inntekter } = vedtak;
+  return (
+    <div className={'page-break'}>
+      <h2>Vedtak</h2>
+      <h3>Resultat</h3>
+      <div>Innvilge</div>
+      <Vedtaksperioder perioder={perioder} />
+      <div className={'page-break'}>
+        <Begrunnelse begrunnelse={periodeBegrunnelse} />
+        <Inntektsperioder inntekter={inntekter} />
+      </div>
+      <div className={'page-break'}>
+        <Begrunnelse begrunnelse={inntektBegrunnelse} />
+      </div>
+    </div>
+  );
+};

--- a/src/server/components/InnvilgetOvergangsstønad.tsx
+++ b/src/server/components/InnvilgetOvergangsstønad.tsx
@@ -1,16 +1,9 @@
 import React from 'react';
-import {
-  aktivitetsTypeTilTekst,
-  IInnvilgeVedtakOvergangsstønad,
-  ISøknadsdatoer,
-  periodetypeTilTekst,
-} from '../../typer/dokumentApi';
-import {
-  formaterNullableIsoDato,
-  formaterNullableMånedÅr,
-  formaterBeløp,
-  parseOgFormaterÅrMåned,
-} from '../utils/util';
+import { IInnvilgeVedtakOvergangsstønad, ISøknadsdatoer } from '../../typer/dokumentApi';
+import { Begrunnelse } from './InnvilgeVedtak/Begrunnelse';
+import { Inntektsperioder } from './InnvilgeVedtak/Inntektsperioder';
+import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
+import { Vedtaksperioder } from './InnvilgeVedtak/Vedtaksperioder';
 
 export const InnvilgetOvergangsstønad: React.FC<{
   vedtak: IInnvilgeVedtakOvergangsstønad;
@@ -23,44 +16,18 @@ export const InnvilgetOvergangsstønad: React.FC<{
       <h3>Resultat</h3>
       <div>Innvilge</div>
       {søknadsdatoer && (
-        <>
-          <h3>Søknadsinformasjon</h3>
-          <div>Søknadsdato: {formaterNullableIsoDato(søknadsdatoer.søknadsdato)}</div>
-          <div>Søker stønad fra: {formaterNullableMånedÅr(søknadsdatoer?.søkerStønadFra)}</div>
-        </>
+        <Søknadsinformasjon
+          søknadsdato={søknadsdatoer.søknadsdato}
+          søkerStønadFra={søknadsdatoer.søkerStønadFra}
+        />
       )}
-      <h3>Vedtaksperiode</h3>
-      {perioder.map((periode, indeks) => {
-        return (
-          <div key={indeks}>
-            <h4>
-              Fra og med {parseOgFormaterÅrMåned(periode.årMånedFra)} til og med{' '}
-              {parseOgFormaterÅrMåned(periode.årMånedTil)}
-            </h4>
-            <div>Periodetype: {periodetypeTilTekst[periode.periodeType]}</div>
-            <div>Aktivitet: {aktivitetsTypeTilTekst[periode.aktivitet]}</div>
-          </div>
-        );
-      })}
+      <Vedtaksperioder perioder={perioder} />
       <div className={'page-break'}>
-        <h4>Begrunnelse</h4>
-        <p style={{ whiteSpace: 'pre-wrap' }}>{periodeBegrunnelse}</p>
-        <h3>Inntekt</h3>
-        {inntekter.map((inntekt, indeks) => {
-          return (
-            <div key={indeks}>
-              <h4>Fra og med {parseOgFormaterÅrMåned(inntekt.årMånedFra)}</h4>
-              <div>Dagsats: {formaterBeløp(inntekt.dagsats || 0)}</div>
-              <div>Månedsinntekt: {formaterBeløp(inntekt.månedsinntekt || 0)}</div>
-              <div>Forventet inntekt (år): {formaterBeløp(inntekt.forventetInntekt || 0)}</div>
-              <div>Samordningsfradrag (mnd): {formaterBeløp(inntekt.samordningsfradrag || 0)}</div>
-            </div>
-          );
-        })}
+        <Begrunnelse begrunnelse={periodeBegrunnelse} />
+        <Inntektsperioder inntekter={inntekter} />
       </div>
       <div className={'page-break'}>
-        <h4>Begrunnelse</h4>
-        <p style={{ whiteSpace: 'pre-wrap' }}>{inntektBegrunnelse}</p>
+        <Begrunnelse begrunnelse={inntektBegrunnelse} />
       </div>
     </div>
   );

--- a/src/server/components/InnvilgetSkolepenger.tsx
+++ b/src/server/components/InnvilgetSkolepenger.tsx
@@ -4,12 +4,9 @@ import {
   ISøknadsdatoer,
   studietypeTilTekst,
 } from '../../typer/dokumentApi';
-import {
-  formaterNullableIsoDato,
-  formaterNullableMånedÅr,
-  parseOgFormaterÅrMåned,
-  tilSkoleår,
-} from '../utils/util';
+import { parseOgFormaterÅrMåned, tilSkoleår } from '../utils/util';
+import { Begrunnelse } from './InnvilgeVedtak/Begrunnelse';
+import { Søknadsinformasjon } from './InnvilgeVedtak/Søknadsinformasjon';
 
 export const InnvilgetSkolepenger: React.FC<{
   vedtak: IInnvilgeVedtakSkolepenger;
@@ -22,9 +19,10 @@ export const InnvilgetSkolepenger: React.FC<{
       <div>Innvilge</div>
       {søknadsdatoer && (
         <>
-          <h3>Søknadsinformasjon</h3>
-          <div>Søknadsdato: {formaterNullableIsoDato(søknadsdatoer.søknadsdato)}</div>
-          <div>Søker stønad fra: {formaterNullableMånedÅr(søknadsdatoer?.søkerStønadFra)}</div>
+          <Søknadsinformasjon
+            søknadsdato={søknadsdatoer.søknadsdato}
+            søkerStønadFra={søknadsdatoer.søkerStønadFra}
+          />
         </>
       )}
 
@@ -78,8 +76,7 @@ export const InnvilgetSkolepenger: React.FC<{
       })}
 
       <div className={'page-break'}>
-        <h4>Begrunnelse</h4>
-        <p style={{ whiteSpace: 'pre-wrap' }}>{vedtak.begrunnelse}</p>
+        <Begrunnelse begrunnelse={vedtak.begrunnelse} />
       </div>
     </div>
   );

--- a/src/server/components/Vedtak.tsx
+++ b/src/server/components/Vedtak.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   EBehandlingResultat,
+  EBehandlingÅrsak,
   EStønadType,
   IInnvilgeVedtakBarnetilsyn,
   IInnvilgeVedtakOvergangsstønad,
@@ -12,16 +13,23 @@ import { AvslåVedtak } from './AvslåVedtak';
 import { InnvilgetOvergangsstønad } from './InnvilgetOvergangsstønad';
 import { InnvilgetBarnetilsyn } from './InnvilgetBarnetilsyn';
 import { InnvilgetSkolepenger } from './InnvilgetSkolepenger';
+import { InnvilgetGOmregning } from './InnvilgetGOmregning';
 
 export const Vedtak: React.FC<{
   stønadstype: EStønadType;
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
-}> = ({ stønadstype, vedtak, søknadsdatoer }) => {
+  årsak: EBehandlingÅrsak;
+}> = ({ stønadstype, vedtak, søknadsdatoer, årsak }) => {
   switch (vedtak.resultatType) {
     case EBehandlingResultat.INNVILGE:
       return (
-        <InnvilgetVedtak stønadstype={stønadstype} vedtak={vedtak} søknadsdatoer={søknadsdatoer} />
+        <InnvilgetVedtak
+          stønadstype={stønadstype}
+          vedtak={vedtak}
+          søknadsdatoer={søknadsdatoer}
+          årsak={årsak}
+        />
       );
     case EBehandlingResultat.AVSLÅ:
       return <AvslåVedtak {...vedtak} />;
@@ -34,7 +42,12 @@ const InnvilgetVedtak: React.FC<{
   stønadstype: EStønadType;
   vedtak: IVedtak;
   søknadsdatoer?: ISøknadsdatoer;
-}> = ({ stønadstype, vedtak, søknadsdatoer }) => {
+  årsak: EBehandlingÅrsak;
+}> = ({ stønadstype, vedtak, søknadsdatoer, årsak }) => {
+  if (årsak === EBehandlingÅrsak.G_OMREGNING) {
+    return <InnvilgetGOmregning vedtak={vedtak as IInnvilgeVedtakOvergangsstønad} />;
+  }
+
   switch (stønadstype) {
     case EStønadType.OVERGANGSSTØNAD:
       return (

--- a/src/typer/dokumentApi.ts
+++ b/src/typer/dokumentApi.ts
@@ -134,6 +134,7 @@ export enum EBehandlingÅrsak {
   NYE_OPPLYSNINGER = 'NYE_OPPLYSNINGER',
   KLAGE = 'KLAGE',
   MIGRERING = 'MIGRERING',
+  G_OMREGNING = 'G_OMREGNING',
 }
 
 export const behandlingÅrsakTilTekst: Record<EBehandlingÅrsak, string> = {
@@ -141,6 +142,7 @@ export const behandlingÅrsakTilTekst: Record<EBehandlingÅrsak, string> = {
   NYE_OPPLYSNINGER: 'Nye opplysninger',
   KLAGE: 'Klage',
   MIGRERING: 'Migrering',
+  G_OMREGNING: 'G-omregning',
 };
 
 export interface IPeriode {


### PR DESCRIPTION
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12365)

### Hvorfor er dette nødvendig? ✨ 
Fordi SB kun ser vedtak og beregningssiden ved en g-omregning er det ikke nødvendig å ta med informasjonen fra de andre sidene i blanketten. Det vises derfor kun frem `Vedtak` delen nå. `Søknadsinformasjon` er heller ikke nødvendig å ta med da dette ikke gir mening for en G-omregning (ingen søknad). 

### Hva er gjort? 🤔

- Skjult alt utenom vedtak om årsak = gomregning
- Lagd egne komponenter for deler av blankett som brukes flere steder
- Lagd en egen komponent for `InnvilgetGOmregning` (Lik som `InnvilgetOvergangsstønad` uten stønadsinformasjon)

### Bilder
Har testet alle typer innvilget for å sjekke at de ser like ut. 
<img width="782" alt="image" src="https://user-images.githubusercontent.com/46678893/237021638-596350fb-e39a-43c1-875b-8ee41f4183a1.png">
