### PR TITLE
Skal ikke ha utgifter i skolepenger-blanketten

### DIFF
--- a/src/server/components/InnvilgetSkolepenger.tsx
+++ b/src/server/components/InnvilgetSkolepenger.tsx
@@ -35,8 +35,7 @@ export const InnvilgetSkolepenger: React.FC<{
             <table>
               <thead>
                 <tr>
-                  <th>Utgiftsdato</th>
-                  <th>Utgifter</th>
+                  <th>Utgiftsmåned</th>
                   <th>Stønadsbeløp</th>
                 </tr>
               </thead>
@@ -44,7 +43,6 @@ export const InnvilgetSkolepenger: React.FC<{
                 {skoleårsperiode.utgiftsperioder.map(utgift => (
                   <tr>
                     <td>{parseOgFormaterÅrMåned(utgift.årMånedFra)}</td>
-                    <td>{utgift.utgifter}</td>
                     <td>{utgift.stønad}</td>
                   </tr>
                 ))}

--- a/src/typer/dokumentApi.ts
+++ b/src/typer/dokumentApi.ts
@@ -68,7 +68,6 @@ export enum ESkolepengerStudietype {
 
 export type ISkolepengerUtgift = {
   årMånedFra: string;
-  utgifter: number;
   stønad: number;
 };
 


### PR DESCRIPTION
Etter modernisering av skolepenger skal vi ikke lenger ha utgifter som et felt saksbehandler skriver inn. Følgelig gir det ikke mening å vise det i blanketten heller.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12239)