### PR TITLE
Fjern CPU-limit

### DIFF
--- a/.build/nais-dev.yaml
+++ b/.build/nais-dev.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   port: 8033
   liveness:
     path: /api/status
@@ -42,7 +41,6 @@ spec:
     enabled: true
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi

--- a/.build/nais-prod.yaml
+++ b/.build/nais-prod.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   port: 8033
   liveness:
     path: /api/status
@@ -42,7 +41,6 @@ spec:
     enabled: true
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)