### PR TITLE
skal støtte visning av beskrivelse for årsak til revurdering dersom d…

### DIFF
--- a/src/server/components/ÅrsakRevurdering.tsx
+++ b/src/server/components/ÅrsakRevurdering.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   IÅrsakRevurdering,
   opplysningskildeTilTekst,
-  Årsak,
   årsakRevuderingTilTekst,
 } from '../../typer/dokumentApi';
 
@@ -20,7 +19,7 @@ export const ÅrsakRevurdering: React.FC<{ årsakRevurdering?: IÅrsakRevurderin
           <strong>Opplysningsskilde:</strong>{' '}
           {opplysningskildeTilTekst[årsakRevurdering.opplysningskilde]}
         </div>
-        {årsakRevurdering.årsak === Årsak.ANNET && årsakRevurdering.beskrivelse && (
+        {årsakRevurdering.beskrivelse && (
           <div>
             <strong>Begrunnelse:</strong> {årsakRevurdering.beskrivelse}
           </div>


### PR DESCRIPTION
…ette er utfylt, selv om årsaken ikke er satt til annet

Dette gjøres for å vise årsak til revurdering dersom årsak er utfylt. Saksbehandler får nå muligheten til å fylle inn årsak selv om årsaken ikke er satt til `ANNET`. Dette var en etterspurt utbedring etter test av [dette kortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12519)