### PR TITLE
Vedtakshistorikk i blankett

### DIFF
--- a/src/server/components/Dokument.tsx
+++ b/src/server/components/Dokument.tsx
@@ -67,26 +67,28 @@ function gjelderDetteVilkåret(vurdering: IVurdering, vilkårgruppe: string): bo
 }
 
 const Dokument = (dokumentProps: DokumentProps) => {
-  const erManuellGOmregning =
-    dokumentProps.dokumentData.behandling.årsak === EBehandlingÅrsak.G_OMREGNING;
+  const dokumentData = dokumentProps.dokumentData;
+  const erManuellGOmregning = dokumentData.behandling.årsak === EBehandlingÅrsak.G_OMREGNING;
   return (
     <div>
       {!erManuellGOmregning &&
         Object.keys(VilkårGruppe).map(vilkårgruppe => {
-          const vurderinger = dokumentProps.dokumentData.vilkår.vurderinger.filter(vurdering =>
+          const vurderinger = dokumentData.vilkår.vurderinger.filter(vurdering =>
             gjelderDetteVilkåret(vurdering, vilkårgruppe),
           );
           if (vurderinger.length === 0) {
             return null;
           }
-          const grunnlag = dokumentProps.dokumentData.vilkår.grunnlag;
+          const grunnlag = dokumentData.vilkår.grunnlag;
           return vurderinger.map(vurdering => {
             return (
               <div key={vurdering.id} className={'page-break'}>
                 <h2>{vilkårTypeTilTekst[vurdering.vilkårType]}</h2>
                 {registergrunnlagForVilkår(grunnlag, vilkårgruppe, vurdering.barnId)}
                 {vurdering.vilkårType === Vilkår.TIDLIGERE_VEDTAKSPERIODER && (
-                  <TidligereHistorikk />
+                  <TidligereHistorikk
+                    tidligereVedtaksperioder={dokumentData.behandling.tidligereVedtaksperioder}
+                  />
                 )}
                 <Vilkårsvurdering vurdering={vurdering} />
               </div>
@@ -94,10 +96,10 @@ const Dokument = (dokumentProps: DokumentProps) => {
           });
         })}
       <Vedtak
-        stønadstype={dokumentProps.dokumentData.behandling.stønadstype}
-        vedtak={dokumentProps.dokumentData.vedtak}
-        søknadsdatoer={dokumentProps.dokumentData.søknadsdatoer}
-        årsak={dokumentProps.dokumentData.behandling.årsak}
+        stønadstype={dokumentData.behandling.stønadstype}
+        vedtak={dokumentData.vedtak}
+        søknadsdatoer={dokumentData.søknadsdatoer}
+        årsak={dokumentData.behandling.årsak}
       />
     </div>
   );

--- a/src/server/components/Dokument.tsx
+++ b/src/server/components/Dokument.tsx
@@ -19,6 +19,7 @@ import NyttBarnSammePartner from './NyttBarnSammePartner';
 import SagtOppEllerRedusertGrunnlag from './SagtOppEllerRedusertGrunnlag';
 import { Vedtak } from './Vedtak';
 import AlderPåBarnGrunnlag from './AlderPåBarnGrunnlag';
+import { TidligereHistorikk } from './TidligereHistorikk';
 
 interface DokumentProps {
   dokumentData: IDokumentData;
@@ -84,7 +85,9 @@ const Dokument = (dokumentProps: DokumentProps) => {
               <div key={vurdering.id} className={'page-break'}>
                 <h2>{vilkårTypeTilTekst[vurdering.vilkårType]}</h2>
                 {registergrunnlagForVilkår(grunnlag, vilkårgruppe, vurdering.barnId)}
-
+                {vurdering.vilkårType === Vilkår.TIDLIGERE_VEDTAKSPERIODER && (
+                  <TidligereHistorikk />
+                )}
                 <Vilkårsvurdering vurdering={vurdering} />
               </div>
             );

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
-import { ITidligereVedtaksperioder } from '../../typer/dokumentApi';
+import {
+  EPeriodetype,
+  ITidligereVedtaksperioder,
+  periodetypeTilTekst,
+} from '../../typer/dokumentApi';
 
 export const TidligereHistorikk: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
 }> = ({ tidligereVedtaksperioder }) => {
+  const tilDagMånedÅr = (dato: string) => {
+    const [år, måned, dag] = dato.split('-');
+    return `${dag}.${måned}.${år}`;
+  };
+
   const TidligereHistorikkTabell: React.FC = () => {
     return (
       <table>
@@ -11,8 +20,8 @@ export const TidligereHistorikk: React.FC<{
           <tr>
             <th>Periode</th>
             <th>Periodetype</th>
-            <th>Måneder med utbetaling</th>
-            <th>Måneder uten utbetaling</th>
+            <th>Måneder med utbet.</th>
+            <th>Måneder uten utbet.</th>
           </tr>
         </thead>
         {tidligereVedtaksperioder?.sak.periodeHistorikkOvergangsstønad?.map(periode => {
@@ -20,11 +29,16 @@ export const TidligereHistorikk: React.FC<{
             <tbody>
               <tr>
                 <td>
-                  {periode.fom} - {periode.tom}
+                  {tilDagMånedÅr(periode.fom)} - {tilDagMånedÅr(periode.tom)}
                 </td>
-                <td>{periode.vedtaksperiodeType}</td>
+                <td>{periodetypeTilTekst[periode.vedtaksperiodeType] || ''}</td>
                 <td>{periode.antallMåneder}</td>
-                <td>{periode.antallMånederUtenBeløp}</td>
+                <td>
+                  {periode.antallMånederUtenBeløp >= 1 &&
+                  periode.vedtaksperiodeType !== EPeriodetype.SANKSJON
+                    ? periode.antallMånederUtenBeløp
+                    : '-'}
+                </td>
               </tr>
             </tbody>
           );

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -8,48 +8,94 @@ import {
 export const TidligereHistorikk: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
 }> = ({ tidligereVedtaksperioder }) => {
+  const periodeHistorikkOvergangsstønad =
+    tidligereVedtaksperioder?.sak.periodeHistorikkOvergangsstønad;
   const tilDagMånedÅr = (dato: string) => {
     const [år, måned, dag] = dato.split('-');
     return `${dag}.${måned}.${år}`;
   };
 
+  const mapTrueFalse = (bool?: boolean): string =>
+    bool === true ? 'Ja' : bool === false ? 'Nei' : '';
+
+  const formatterBooleanEllerUkjent = (bool?: boolean) =>
+    bool === undefined || bool === null ? 'Ukjent' : mapTrueFalse(bool);
+
   const TidligereHistorikkTabell: React.FC = () => {
+    if (!periodeHistorikkOvergangsstønad || periodeHistorikkOvergangsstønad?.length < 1)
+      return <></>;
+
     return (
       <table>
-        <thead>
-          <tr>
-            <th>Periode</th>
-            <th>Periodetype</th>
-            <th>Måneder med utbet.</th>
-            <th>Måneder uten utbet.</th>
-          </tr>
-        </thead>
-        {tidligereVedtaksperioder?.sak.periodeHistorikkOvergangsstønad?.map(periode => {
+        <tr>
+          <th>Periode</th>
+          <th>Periodetype</th>
+          <th>Måneder med utbet.</th>
+          <th>Måneder uten utbet.</th>
+        </tr>
+        {periodeHistorikkOvergangsstønad?.map(periode => {
           return (
-            <tbody>
-              <tr>
-                <td>
-                  {tilDagMånedÅr(periode.fom)} - {tilDagMånedÅr(periode.tom)}
-                </td>
-                <td>{periodetypeTilTekst[periode.vedtaksperiodeType] || ''}</td>
-                <td>{periode.antallMåneder}</td>
-                <td>
-                  {periode.antallMånederUtenBeløp >= 1 &&
-                  periode.vedtaksperiodeType !== EPeriodetype.SANKSJON
-                    ? periode.antallMånederUtenBeløp
-                    : '-'}
-                </td>
-              </tr>
-            </tbody>
+            <tr>
+              <td>
+                {tilDagMånedÅr(periode.fom)} - {tilDagMånedÅr(periode.tom)}
+              </td>
+              <td>{periodetypeTilTekst[periode.vedtaksperiodeType] || ''}</td>
+              <td>{periode.antallMåneder}</td>
+              <td>
+                {periode.antallMånederUtenBeløp >= 1 &&
+                periode.vedtaksperiodeType !== EPeriodetype.SANKSJON
+                  ? periode.antallMånederUtenBeløp
+                  : '-'}
+              </td>
+            </tr>
           );
         })}
       </table>
     );
   };
+
+  const TidligereHistorikk: React.FC = () => {
+    return (
+      <>
+        <h2>Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd</h2>
+        <h3>Overgangsstønad</h3>
+        <div>
+          <strong>Historikk i EF Sak:</strong>{' '}
+          {formatterBooleanEllerUkjent(tidligereVedtaksperioder?.sak.harTidligereOvergangsstønad)}
+        </div>
+        <div>
+          <strong>Historikk i Infotrygd:</strong>{' '}
+          {formatterBooleanEllerUkjent(
+            tidligereVedtaksperioder?.infotrygd.harTidligereOvergangsstønad,
+          )}
+        </div>
+        <TidligereHistorikkTabell />
+        <h3>Barnetilsyn</h3>
+        <div>
+          <strong>Historikk i EF Sak:</strong>{' '}
+          {formatterBooleanEllerUkjent(tidligereVedtaksperioder?.sak.harTidligereBarnetilsyn)}
+        </div>
+        <div>
+          <strong>Historikk i Infotrygd:</strong>{' '}
+          {formatterBooleanEllerUkjent(tidligereVedtaksperioder?.infotrygd.harTidligereBarnetilsyn)}
+        </div>
+        <h3>Skolepenger</h3>
+        <div>
+          <strong>Historikk i EF Sak:</strong>{' '}
+          {formatterBooleanEllerUkjent(tidligereVedtaksperioder?.sak.harTidligereSkolepenger)}
+        </div>
+        <div>
+          <strong>Historikk i Infotrygd:</strong>{' '}
+          {formatterBooleanEllerUkjent(tidligereVedtaksperioder?.infotrygd.harTidligereSkolepenger)}
+        </div>
+      </>
+    );
+  };
+
   return (
     <>
       <h3>Registerdata</h3>
-      <TidligereHistorikkTabell />
+      <TidligereHistorikk />
     </>
   );
 };

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export const TidligereHistorikk: React.FC = () => {
+  // Hardkodet test
+  const TidligereHistorikkTabell: React.FC = () => {
+    return (
+      <table>
+        <tr>
+          <th>Periode</th>
+          <th>Periodetype</th>
+          <th>Måneder med utbetaling</th>
+          <th>Måneder uten utbetaling</th>
+        </tr>
+        <tr>
+          <td>01.01.2020 - 31.12.2020</td>
+          <td>Hovedperiode</td>
+          <td>1</td>
+          <td>5</td>
+        </tr>
+        <tr>
+          <td>01.01.2019 - 31.12.2019</td>
+          <td>Forlengelse</td>
+          <td>2</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>01.01.2018 - 31.12.2018</td>
+          <td>Hovedperiode</td>
+          <td>8</td>
+          <td>16</td>
+        </tr>
+      </table>
+    );
+  };
+  return (
+    <div>
+      <h3>Registerdata</h3>
+      <TidligereHistorikkTabell />
+    </div>
+  );
+};

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -48,7 +48,7 @@ export const TidligereHistorikk: React.FC<{
   const TidligereHistorikk: React.FC = () => {
     return (
       <>
-        <p>Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd</p>
+        <p>Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd?</p>
         <h3>Overgangsstønad</h3>
         <div>
           <strong>Historikk i EF Sak:</strong>{' '}

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -5,37 +5,41 @@ export const TidligereHistorikk: React.FC = () => {
   const TidligereHistorikkTabell: React.FC = () => {
     return (
       <table>
-        <tr>
-          <th>Periode</th>
-          <th>Periodetype</th>
-          <th>Måneder med utbetaling</th>
-          <th>Måneder uten utbetaling</th>
-        </tr>
-        <tr>
-          <td>01.01.2020 - 31.12.2020</td>
-          <td>Hovedperiode</td>
-          <td>1</td>
-          <td>5</td>
-        </tr>
-        <tr>
-          <td>01.01.2019 - 31.12.2019</td>
-          <td>Forlengelse</td>
-          <td>2</td>
-          <td>-</td>
-        </tr>
-        <tr>
-          <td>01.01.2018 - 31.12.2018</td>
-          <td>Hovedperiode</td>
-          <td>8</td>
-          <td>16</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Periode</th>
+            <th>Periodetype</th>
+            <th>Måneder med utbetaling</th>
+            <th>Måneder uten utbetaling</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>01.01.2020 - 31.12.2020</td>
+            <td>Hovedperiode</td>
+            <td>1</td>
+            <td>5</td>
+          </tr>
+          <tr>
+            <td>01.01.2019 - 31.12.2019</td>
+            <td>Forlengelse</td>
+            <td>2</td>
+            <td>-</td>
+          </tr>
+          <tr>
+            <td>01.01.2018 - 31.12.2018</td>
+            <td>Hovedperiode</td>
+            <td>8</td>
+            <td>16</td>
+          </tr>
+        </tbody>
       </table>
     );
   };
   return (
-    <div>
+    <>
       <h3>Registerdata</h3>
       <TidligereHistorikkTabell />
-    </div>
+    </>
   );
 };

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -4,22 +4,13 @@ import {
   ITidligereVedtaksperioder,
   periodetypeTilTekst,
 } from '../../typer/dokumentApi';
+import { formaterIsoDato, formatterBooleanEllerUkjent } from '../utils/util';
 
 export const TidligereHistorikk: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
 }> = ({ tidligereVedtaksperioder }) => {
   const periodeHistorikkOvergangsstønad =
     tidligereVedtaksperioder?.sak.periodeHistorikkOvergangsstønad;
-  const tilDagMånedÅr = (dato: string) => {
-    const [år, måned, dag] = dato.split('-');
-    return `${dag}.${måned}.${år}`;
-  };
-
-  const mapTrueFalse = (bool?: boolean): string =>
-    bool === true ? 'Ja' : bool === false ? 'Nei' : '';
-
-  const formatterBooleanEllerUkjent = (bool?: boolean) =>
-    bool === undefined || bool === null ? 'Ukjent' : mapTrueFalse(bool);
 
   const TidligereHistorikkTabell: React.FC = () => {
     if (!periodeHistorikkOvergangsstønad || periodeHistorikkOvergangsstønad?.length < 1)
@@ -37,7 +28,7 @@ export const TidligereHistorikk: React.FC<{
           return (
             <tr>
               <td>
-                {tilDagMånedÅr(periode.fom)} - {tilDagMånedÅr(periode.tom)}
+                {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
               </td>
               <td>{periodetypeTilTekst[periode.vedtaksperiodeType] || ''}</td>
               <td>{periode.antallMåneder}</td>
@@ -57,7 +48,7 @@ export const TidligereHistorikk: React.FC<{
   const TidligereHistorikk: React.FC = () => {
     return (
       <>
-        <h2>Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd</h2>
+        <p>Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd</p>
         <h3>Overgangsstønad</h3>
         <div>
           <strong>Historikk i EF Sak:</strong>{' '}

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -12,7 +12,7 @@ export const TidligereHistorikk: React.FC<{
   const periodeHistorikkOvergangsstønad =
     tidligereVedtaksperioder?.sak.periodeHistorikkOvergangsstønad;
 
-  const TidligereHistorikkTabell: React.FC = () => {
+  const TidligereHistorikkOvergangsstønadTabell: React.FC = () => {
     if (!periodeHistorikkOvergangsstønad || periodeHistorikkOvergangsstønad?.length < 1)
       return <></>;
 
@@ -60,7 +60,7 @@ export const TidligereHistorikk: React.FC<{
             tidligereVedtaksperioder?.infotrygd.harTidligereOvergangsstønad,
           )}
         </div>
-        <TidligereHistorikkTabell />
+        <TidligereHistorikkOvergangsstønadTabell />
         <h3>Barnetilsyn</h3>
         <div>
           <strong>Historikk i EF Sak:</strong>{' '}

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { ITidligereVedtaksperioder } from '../../typer/dokumentApi';
 
-export const TidligereHistorikk: React.FC = () => {
-  // Hardkodet test
+export const TidligereHistorikk: React.FC<{
+  tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
+}> = ({ tidligereVedtaksperioder }) => {
   const TidligereHistorikkTabell: React.FC = () => {
     return (
       <table>
@@ -13,26 +15,20 @@ export const TidligereHistorikk: React.FC = () => {
             <th>Måneder uten utbetaling</th>
           </tr>
         </thead>
-        <tbody>
-          <tr>
-            <td>01.01.2020 - 31.12.2020</td>
-            <td>Hovedperiode</td>
-            <td>1</td>
-            <td>5</td>
-          </tr>
-          <tr>
-            <td>01.01.2019 - 31.12.2019</td>
-            <td>Forlengelse</td>
-            <td>2</td>
-            <td>-</td>
-          </tr>
-          <tr>
-            <td>01.01.2018 - 31.12.2018</td>
-            <td>Hovedperiode</td>
-            <td>8</td>
-            <td>16</td>
-          </tr>
-        </tbody>
+        {tidligereVedtaksperioder?.sak.periodeHistorikkOvergangsstønad?.map(periode => {
+          return (
+            <tbody>
+              <tr>
+                <td>
+                  {periode.fom} - {periode.tom}
+                </td>
+                <td>{periode.vedtaksperiodeType}</td>
+                <td>{periode.antallMåneder}</td>
+                <td>{periode.antallMånederUtenBeløp}</td>
+              </tr>
+            </tbody>
+          );
+        })}
       </table>
     );
   };

--- a/src/server/components/Vilkårsvurdering.tsx
+++ b/src/server/components/Vilkårsvurdering.tsx
@@ -11,7 +11,6 @@ import OppfyltIkon from './ikoner/OppfyltIkon';
 import IkkeOppfylt from './ikoner/IkkeOppfylt';
 import InfoIkon from './ikoner/InfoIkon';
 import { IkkeVurdert } from './ikoner/IkkeVurdert';
-import { TidligereHistorikk } from './TidligereHistorikk';
 
 interface Props {
   vurdering: IVurdering;
@@ -42,7 +41,6 @@ const Vilkårsvurdering: React.FC<Props> = ({ vurdering }) => {
         <div className={'vilkårsresultat-ikon'}>
           <span style={{ paddingBottom: '20%' }}>{resultatIkon(resultat)}</span>
         </div>
-        {Vilkår.TIDLIGERE_VEDTAKSPERIODER && <TidligereHistorikk />}
       </div>
 
       {vurdering.delvilkårsvurderinger

--- a/src/server/components/Vilkårsvurdering.tsx
+++ b/src/server/components/Vilkårsvurdering.tsx
@@ -11,6 +11,7 @@ import OppfyltIkon from './ikoner/OppfyltIkon';
 import IkkeOppfylt from './ikoner/IkkeOppfylt';
 import InfoIkon from './ikoner/InfoIkon';
 import { IkkeVurdert } from './ikoner/IkkeVurdert';
+import { TidligereHistorikk } from './TidligereHistorikk';
 
 interface Props {
   vurdering: IVurdering;
@@ -41,6 +42,7 @@ const Vilkårsvurdering: React.FC<Props> = ({ vurdering }) => {
         <div className={'vilkårsresultat-ikon'}>
           <span style={{ paddingBottom: '20%' }}>{resultatIkon(resultat)}</span>
         </div>
+        <TidligereHistorikk />
       </div>
 
       {vurdering.delvilkårsvurderinger

--- a/src/server/components/Vilkårsvurdering.tsx
+++ b/src/server/components/Vilkårsvurdering.tsx
@@ -42,7 +42,7 @@ const Vilkårsvurdering: React.FC<Props> = ({ vurdering }) => {
         <div className={'vilkårsresultat-ikon'}>
           <span style={{ paddingBottom: '20%' }}>{resultatIkon(resultat)}</span>
         </div>
-        <TidligereHistorikk />
+        {Vilkår.TIDLIGERE_VEDTAKSPERIODER && <TidligereHistorikk />}
       </div>
 
       {vurdering.delvilkårsvurderinger

--- a/src/server/utils/util.ts
+++ b/src/server/utils/util.ts
@@ -43,3 +43,9 @@ export const månedÅrTilDate = (årMåned: string): Date => {
 
 export const formaterBeløp = (verdi: number): string =>
   Number(verdi).toLocaleString('no-NO', { currency: 'NOK' }) + ' kr';
+
+const mapTrueFalse = (bool?: boolean): string =>
+  bool === true ? 'Ja' : bool === false ? 'Nei' : '';
+
+export const formatterBooleanEllerUkjent = (bool?: boolean) =>
+  bool === undefined || bool === null ? 'Ukjent' : mapTrueFalse(bool);

--- a/src/typer/dokumentApi.ts
+++ b/src/typer/dokumentApi.ts
@@ -10,6 +10,28 @@ export interface IBehandling {
   årsak: EBehandlingÅrsak;
   stønadstype: EStønadType;
   årsakRevurdering?: IÅrsakRevurdering;
+  tidligereVedtaksperioder?: ITidligereVedtaksperioder;
+}
+
+export interface ITidligereVedtaksperioder {
+  infotrygd: ITidligereInnvilgetVedtak;
+  sak: ITidligereInnvilgetVedtak;
+  historiskPensjon: boolean;
+}
+
+interface ITidligereInnvilgetVedtak {
+  harTidligereOvergangsstønad: boolean;
+  harTidligereBarnetilsyn: boolean;
+  harTidligereSkolepenger: boolean;
+  periodeHistorikkOvergangsstønad?: IGrunnlagsdataPeriodeHistorikk[];
+}
+
+interface IGrunnlagsdataPeriodeHistorikk {
+  vedtaksperiodeType: EPeriodetype;
+  fom: string;
+  tom: string;
+  antallMåneder: number;
+  antallMånederUtenBeløp: number;
 }
 
 export interface ISøknadsdatoer {
@@ -172,11 +194,23 @@ export interface IPeriodeBarnetilsyn {
 export enum EPeriodetype {
   PERIODE_FØR_FØDSEL = 'PERIODE_FØR_FØDSEL',
   HOVEDPERIODE = 'HOVEDPERIODE',
+  FORLENGELSE = 'FORLENGELSE',
+  MIDLERTIDIG_OPPHØR = 'MIDLERTIDIG_OPPHØR',
+  MIGRERING = 'MIGRERING',
+  SANKSJON = 'SANKSJON',
+  UTVIDELSE = 'UTVIDELSE',
+  NY_PERIODE_FOR_NYTT_BARN = 'NY_PERIODE_FOR_NYTT_BARN',
 }
 
 export const periodetypeTilTekst: Record<EPeriodetype, string> = {
   PERIODE_FØR_FØDSEL: 'Periode før fødsel',
   HOVEDPERIODE: 'Hovedperiode',
+  FORLENGELSE: 'Forlengelse',
+  MIDLERTIDIG_OPPHØR: 'Midlertidig opphør',
+  MIGRERING: 'Migrering',
+  SANKSJON: 'Sanksjon',
+  UTVIDELSE: 'Utvidelse',
+  NY_PERIODE_FOR_NYTT_BARN: 'Ny periode for nytt barn',
 };
 
 export enum EAktivitet {


### PR DESCRIPTION
Ønsker å vise tidligere vedtakshistorikk i blankett.

ef-sak: https://github.com/navikt/familie-ef-sak/pull/2424
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15686

Bildet viser hvordan blanketten/pdf ser ut med tidligere vedtakshistorikk: 
![image](https://github.com/navikt/familie-ef-blankett/assets/141132903/0b257457-448a-40df-a663-b852605fd959)

