### PR TITLE
Vise punktet PE PP i blankett

### DIFF
--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -47,6 +47,13 @@ export const TidligereHistorikk: React.FC<{
           <strong>Historikk i Infotrygd:</strong>{' '}
           {mapBooleanTilString(tidligereVedtaksperioder?.infotrygd.harTidligereSkolepenger)}
         </div>
+        <br />
+        <div>
+          <strong>
+            Har bruker fått stønad før desember 2008 - <span>Infotrygd (PE PP)</span>{' '}
+          </strong>
+          {mapBooleanTilString(tidligereVedtaksperioder?.historiskPensjon)}
+        </div>
       </>
     );
   };

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -50,7 +50,7 @@ export const TidligereHistorikk: React.FC<{
         <br />
         <div>
           <strong>
-            Har bruker fått stønad før desember 2008 - <span>Infotrygd (PE PP)</span>{' '}
+            Har bruker fått stønad før desember 2008 - <span>Infotrygd (PE PP):</span>{' '}
           </strong>
           {mapBooleanTilString(tidligereVedtaksperioder?.historiskPensjon)}
         </div>

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -49,9 +49,7 @@ export const TidligereHistorikk: React.FC<{
         </div>
         <br />
         <div>
-          <strong>
-            Har bruker fått stønad før desember 2008 - <span>Infotrygd (PE PP):</span>{' '}
-          </strong>
+          <strong>Har bruker fått stønad før desember 2008 - Infotrygd (PE PP): </strong>
           {mapBooleanTilString(tidligereVedtaksperioder?.historiskPensjon)}
         </div>
       </>


### PR DESCRIPTION
Hadde glemt å ta med punktet "Har bruker fått stønad før desember 2008 - Infotrygd (PE PP)", har derfor lagt til dette nå.
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15686

![image](https://github.com/navikt/familie-ef-blankett/assets/141132903/274d1764-e245-4b79-a2a1-f06cc76b944e)
