### PR TITLE
Vil håndtere gamle behandlinger fra ef-sak (som mangler grunnlagsdata…

### DIFF
--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -11,7 +11,7 @@ export const TidligereHistorikk: React.FC<{
   tidligereVedtaksperioder: ITidligereVedtaksperioder | undefined;
 }> = ({ tidligereVedtaksperioder }) => {
   const periodeHistorikkOvergangsstønad =
-    tidligereVedtaksperioder?.sak.periodeHistorikkOvergangsstønad;
+    tidligereVedtaksperioder?.sak?.periodeHistorikkOvergangsstønad;
 
   const TidligereHistorikk: React.FC = () => {
     return (
@@ -20,7 +20,7 @@ export const TidligereHistorikk: React.FC<{
         <h3>Overgangsstønad</h3>
         <div>
           <strong>Historikk i EF Sak:</strong>{' '}
-          {mapBooleanTilString(tidligereVedtaksperioder?.sak.harTidligereOvergangsstønad)}
+          {mapBooleanTilString(tidligereVedtaksperioder?.sak?.harTidligereOvergangsstønad)}
         </div>
         <div>
           <strong>Historikk i Infotrygd:</strong>{' '}
@@ -32,7 +32,7 @@ export const TidligereHistorikk: React.FC<{
         <h3>Barnetilsyn</h3>
         <div>
           <strong>Historikk i EF Sak:</strong>{' '}
-          {mapBooleanTilString(tidligereVedtaksperioder?.sak.harTidligereBarnetilsyn)}
+          {mapBooleanTilString(tidligereVedtaksperioder?.sak?.harTidligereBarnetilsyn)}
         </div>
         <div>
           <strong>Historikk i Infotrygd:</strong>{' '}
@@ -41,7 +41,7 @@ export const TidligereHistorikk: React.FC<{
         <h3>Skolepenger</h3>
         <div>
           <strong>Historikk i EF Sak:</strong>{' '}
-          {mapBooleanTilString(tidligereVedtaksperioder?.sak.harTidligereSkolepenger)}
+          {mapBooleanTilString(tidligereVedtaksperioder?.sak?.harTidligereSkolepenger)}
         </div>
         <div>
           <strong>Historikk i Infotrygd:</strong>{' '}

--- a/src/typer/dokumentApi.ts
+++ b/src/typer/dokumentApi.ts
@@ -15,7 +15,7 @@ export interface IBehandling {
 
 export interface ITidligereVedtaksperioder {
   infotrygd: ITidligereInnvilgetVedtak;
-  sak: ITidligereInnvilgetVedtak;
+  sak?: ITidligereInnvilgetVedtak;
   historiskPensjon: boolean;
 }
 


### PR DESCRIPTION
Vil håndtere gamle behandlinger fra ef-sak (som mangler grunnlagsdata på behandling) -> "sak": null.

Bug i prod: 
https://familie-prosessering.intern.nav.no/service/familie-ef-sak/task/1005359

Ønsker at disse skal mappes til "ukjent".

Grunnlagsdata som fører til feil: (grunnlagsdata opprettet i februar 2022)  

"tidligereVedtaksperioder": {
    "infotrygd": {
      "harTidligereOvergangsstønad": false,
      "harTidligereBarnetilsyn": false,
      "harTidligereSkolepenger": false,
      "periodeHistorikkOvergangsstønad": []
    },
    "sak": null,
    "historiskPensjon": null
  },

Blankett etter endring: 
![image](https://github.com/navikt/familie-ef-blankett/assets/53942238/e5c7324b-f09f-407f-a4ab-b32c1c81a2ba)


