### PR TITLE
Trenger å skrive ut tidligere vedtaksperioder for barnetilsyn

### DIFF
--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -39,7 +39,7 @@ export const TidligereHistorikk: React.FC<{
           {mapBooleanTilString(tidligereVedtaksperioder?.infotrygd.harTidligereBarnetilsyn)}
         </div>
         <TidligereHistorikkBarnetilsynTabell
-          periodeHistorikkOvergangsstønad={periodeHistorikkOvergangsstønad}
+          periodeHistorikkBarnetilsyn={periodeHistorikkOvergangsstønad}
         />
         <h3>Skolepenger</h3>
         <div>
@@ -102,16 +102,16 @@ const TidligereHistorikkOvergangsstønadTabell: React.FC<{
 };
 
 const TidligereHistorikkBarnetilsynTabell: React.FC<{
-  periodeHistorikkOvergangsstønad: IGrunnlagsdataPeriodeHistorikk[] | undefined;
-}> = ({ periodeHistorikkOvergangsstønad }) => {
-  if (!periodeHistorikkOvergangsstønad || periodeHistorikkOvergangsstønad?.length < 1) return <></>;
+  periodeHistorikkBarnetilsyn: IGrunnlagsdataPeriodeHistorikk[] | undefined;
+}> = ({ periodeHistorikkBarnetilsyn }) => {
+  if (!periodeHistorikkBarnetilsyn || periodeHistorikkBarnetilsyn?.length < 1) return <></>;
 
   return (
     <table>
       <tr>
         <th>Periode</th>
       </tr>
-      {periodeHistorikkOvergangsstønad?.map(periode => {
+      {periodeHistorikkBarnetilsyn?.map(periode => {
         return (
           <tr>
             <td>

--- a/src/server/components/TidligereHistorikk.tsx
+++ b/src/server/components/TidligereHistorikk.tsx
@@ -38,6 +38,9 @@ export const TidligereHistorikk: React.FC<{
           <strong>Historikk i Infotrygd:</strong>{' '}
           {mapBooleanTilString(tidligereVedtaksperioder?.infotrygd.harTidligereBarnetilsyn)}
         </div>
+        <TidligereHistorikkBarnetilsynTabell
+          periodeHistorikkOvergangsstønad={periodeHistorikkOvergangsstønad}
+        />
         <h3>Skolepenger</h3>
         <div>
           <strong>Historikk i EF Sak:</strong>{' '}
@@ -90,6 +93,29 @@ const TidligereHistorikkOvergangsstønadTabell: React.FC<{
               periode.vedtaksperiodeType !== EPeriodetype.SANKSJON
                 ? periode.antallMånederUtenBeløp
                 : '-'}
+            </td>
+          </tr>
+        );
+      })}
+    </table>
+  );
+};
+
+const TidligereHistorikkBarnetilsynTabell: React.FC<{
+  periodeHistorikkOvergangsstønad: IGrunnlagsdataPeriodeHistorikk[] | undefined;
+}> = ({ periodeHistorikkOvergangsstønad }) => {
+  if (!periodeHistorikkOvergangsstønad || periodeHistorikkOvergangsstønad?.length < 1) return <></>;
+
+  return (
+    <table>
+      <tr>
+        <th>Periode</th>
+      </tr>
+      {periodeHistorikkOvergangsstønad?.map(periode => {
+        return (
+          <tr>
+            <td>
+              {formaterIsoDato(periode.fom)} - {formaterIsoDato(periode.tom)}
             </td>
           </tr>
         );


### PR DESCRIPTION
Hvorfor ? 

Vi trenger å vise tidligere vedtaksperioder for barnetilsyn også i blankett, siden dette også vises i frontend, ref: https://github.com/navikt/familie-ef-sak-frontend/pull/2642

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15808

![image](https://github.com/navikt/familie-ef-blankett/assets/56258085/b4b807fd-6e7f-4323-8c88-c4e8b8933f33)
